### PR TITLE
Fixed incorrect syntax in Week 11 prac

### DIFF
--- a/week 11 - recursive data structures/recursiveDataStructures.md
+++ b/week 11 - recursive data structures/recursiveDataStructures.md
@@ -55,7 +55,7 @@ class Time {
 		minute = m;
 	}
 	
-	public Date(Date source) {
+	public Time(Date source) {
 		day = source.day;
 		month = source.month;
 		year = source.year;

--- a/week 11 - recursive data structures/recursiveDataStructures.md
+++ b/week 11 - recursive data structures/recursiveDataStructures.md
@@ -14,7 +14,7 @@ Draw a memory diagram for the objects (`t1`, `t2`, `app`) in the following code.
 class Time {
 	public day, month, year;
 	public hour, minute;
-	public Date(int d, int m, int y, int h, int m) {
+	public Time(int d, int m, int y, int h, int m) {
 		day = d;
 		month = m;
 		year = y;
@@ -47,7 +47,7 @@ Draw a memory diagram for the objects (`t1`, `t2`, `app`) in the following code.
 class Time {
 	public day, month, year;
 	public hour, minute;
-	public Date(int d, int m, int y, int h, int m) {
+	public Time(int d, int m, int y, int h, int m) {
 		day = d;
 		month = m;
 		year = y;


### PR DESCRIPTION
There were a couple of constructors for the `Time` class which had the `Date` definiton, which obviously isn't correct. Hopefully this should clear up a bit of confusion for some people.